### PR TITLE
Fix tests: latexrun_args should not be mutated directly

### DIFF
--- a/test/run
+++ b/test/run
@@ -72,7 +72,7 @@ def test(latexrun_path, latexrun_args, input_path):
     m = re.search(pre + 'bibtex-cmd: (.*)', input_src, re.I|re.M)
     if m:
         bibtex_cmd = m.group(1)
-        latexrun_args += ["--bibtex-cmd",  bibtex_cmd]
+        latexrun_args = latexrun_args + ["--bibtex-cmd",  bibtex_cmd]
 
     m = re.search(pre + 'output:\n((?:' + pre + '.*\n)*)', input_src, re.I|re.M)
     if m:


### PR DESCRIPTION
`latexrun_args` is kept between tests, therefore it should not be mutated.
Running `./runall` failed because of that for me.